### PR TITLE
fix: mark Tabbed Settings compatible with Cura 5.13

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,9 @@
 {
     "name": "Tabbed Settings",
     "author": "fieldOfView",
-    "version": "1.0.9",
+    "version": "1.0.10-DEV",
     "minimum_cura_version": "5.0",
-    "maximum_cura_version": "5.12",
+    "maximum_cura_version": "5.13",
     "description": "Replaces the long scrolling settings view with a tabbed alternative.",
     "supported_sdk_versions": [
         "8.0.0", "8.1.0", "8.2.0", "8.3.0", "8.4.0", "8.5.0", "8.6.0", "8.7.0", "8.8.0", "8.9.0", "8.10.0", "8.11.0", "8.12.0"


### PR DESCRIPTION
## Why

Cura 5.13 currently refuses to initialize Tabbed Settings because the plugin's compatibility metadata caps support at Cura 5.12. Cura 5.13 continues to use SDK 8.12.0, which the plugin already supports, and the Cura QML files patched by the plugin are unchanged from 5.12.

## What Changed

- Start the next development version as `1.0.10-DEV`.
- Mark the plugin compatible through Cura 5.13.
- Keep the supported SDK list unchanged through 8.12.0.

## Verification

- Installed the patched plugin in Cura 5.13 and confirmed the log reports `Loaded plugin TabbedSettingsPlugin 1.0.10-DEV` without the Tabbed Settings version-mismatch path.
- Confirmed `TabbedSettingsView.qml` initializes; its existing non-fatal warnings match the working Cura 5.12 baseline.
- Compared printer, extruder, quality-profile, material, definition-change, and user-profile data before and after startup with no changes.
- Sliced the Calibration Shapes calibration cube with CuraEngine 5.13 successfully: 100 layers and 22,138 lines of generated G-code.
